### PR TITLE
Add RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ npm install
 
 ### Running the app locally 
 ```bash
+# Make sure your virtual env is activated
+source venv/bin/activate
 cd app/
 
 # Export env variables. Use setup_prod.sh for prod
@@ -39,7 +41,7 @@ bash run.sh
 
 The app should now be running on localhost:5000.
 
-### Querying DB
+### Querying the DB
 Using sqlite directly
 ```
 sqlite3
@@ -52,6 +54,33 @@ Using flask shell
 ```
 flask shell
 Room.query.all()
+```
+
+### Running the app locally in production mode
+We use multiple workers in production, so we need a message queue to coordinate websocket broadcasting. We use SocketIO for websockets and RabbitMQ as our message queue.
+```bash
+# Install kombu (this also comes installed as part of your dev env)
+source venv/bin/activate
+pip install kombu
+# or
+pip install -r requirements.txt
+
+# Install rabbitmq
+brew install rabbitmq
+
+# If not in path, add it
+export PATH=$PATH:/usr/local/opt/rabbitmq/sbin
+
+# Start server
+rabbitmq-server
+
+# Run the app in production mode
+cd add/
+source setup_prod.sh
+flask run
+
+# To shut down the rabbitmq server
+rabbitmqctl shutdown
 ```
 
 ### Jitsi API documentation

--- a/app/config.py
+++ b/app/config.py
@@ -16,11 +16,15 @@ class Config:
 class DevelopmentConfig(Config):
     DEBUG = True
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'db.sqlite')
+    MESSAGE_QUEUE = None
 
 class ProductionConfig(Config):
     # These URIs are the same for now. If we ever introduce tests we'll want to have
     # a test config that has its own db that doesn't interfere with these.
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'db.sqlite')
+    # We use multiple workers in production, so we need a message queue to coordinate
+    # websocket broadcasting
+    MESSAGE_QUEUE = 'amqp://'
 
 config = {
     'development': DevelopmentConfig,

--- a/app/jitsi/__init__.py
+++ b/app/jitsi/__init__.py
@@ -31,6 +31,7 @@ def create_app(config_name):
     db.init_app(app)
 
     # SocketIO
-    socketio.init_app(app, cors_allowed_origins='*')
+    queue = config[config_name].MESSAGE_QUEUE
+    socketio.init_app(app, cors_allowed_origins='*', message_queue=queue)
 
     return app

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ Flask-SQLAlchemy==2.4.1
 greenlet==0.4.15
 itsdangerous==1.1.0
 Jinja2==2.11.2
+kombu==4.6.8
 MarkupSafe==1.1.1
 monotonic==1.5
 python-engineio==3.12.1


### PR DESCRIPTION
This works for me locally, though of course I'm not using multiple workers. This only runs rabbitmq if you're in production mode, so this shouldn't affect any local development, and you can still develop locally without installing any rabbitmq dependencies. 