### PR TITLE
Unfuck the Map

### DIFF
--- a/app/client/jsx/Exit.jsx
+++ b/app/client/jsx/Exit.jsx
@@ -11,7 +11,7 @@ class Exit extends Component {
         return (
             <div className="exit">
                 <h1>Goodbye!</h1>
-                <img src={SpecialAvatars.thumb[this.props.user.avatar[1]]}/>
+                <img src={SpecialAvatars.thumb[this.props.user.avatar.color]}/>
             </div>
         )
     }

--- a/app/client/jsx/Navigation.jsx
+++ b/app/client/jsx/Navigation.jsx
@@ -51,8 +51,8 @@ class Navigation extends Component {
         return (
             <div className="navigation-container">
                 <div className="column">
-                    {this.props.showMap &&
-                        <button className={mapButtonClass} disabled={false} onClick={() => onClick('map')}>
+                    {this.props.showMapButton &&
+                        <button className={mapButtonClass} disabled={false} onClick={this.props.handleOpenMap.bind(this)}>
                             <FontAwesomeIcon icon={faMap}/>
                             <span className="navigation-room-name">Map</span>
                         </button>
@@ -85,7 +85,7 @@ class Navigation extends Component {
                 </div>
                 <div className="column column-avatar">
                     <div className="puck-wrapper">
-                      <img src={Avatars[this.props.user.avatar[0]][this.props.user.avatar[1]]}/>
+                      <img src={Avatars[this.props.user.avatar.type][this.props.user.avatar.color]}/>
                     </div>
                 </div>
             </div>

--- a/app/client/jsx/PuckSelect.jsx
+++ b/app/client/jsx/PuckSelect.jsx
@@ -33,7 +33,10 @@ class PuckSelect extends Component {
     this.setState({ avatarDesign: key, rowOpen: index }) }
   handleClickColor(variantKey) {
     this.setState({ avatarColorway: variantKey })
-    this.props.handleSelect([this.state.avatarDesign, variantKey])
+    this.props.handleSelect({
+      type: this.state.avatarDesign,
+      color: variantKey
+    })
   }
 
   render() {

--- a/app/client/jsx/Room.jsx
+++ b/app/client/jsx/Room.jsx
@@ -2,6 +2,8 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import reducers from './reducers.jsx'
 import { Redirect } from 'react-router-dom'
+import { Beforeunload } from 'react-beforeunload';
+import Modal from 'react-modal';
 import JitsiVideo from './JitsiVideo.jsx'
 import ArtRoom from './ArtRoom.jsx'
 import IFrameRoom from './IFrameRoom.jsx'
@@ -9,8 +11,7 @@ import Map from './Map.jsx'
 import Door from './Door.jsx'
 import Adventure from './Adventure.jsx'
 import Navigation from './Navigation.jsx'
-import { HttpApi } from './WebAPI.jsx'
-import { Beforeunload } from 'react-beforeunload';
+import { HttpApi, WebSocketApi } from './WebAPI.jsx'
 
 class Room extends Component {
     /*
@@ -46,35 +47,25 @@ class Room extends Component {
         this.state = {
             room,
             entered: this.roomTypesWithDoors[type] ? entered : true,
-            users: []
+            showMap: false
         }
 
         this.httpApi = new HttpApi()
-        this.socketApi = this.props.socketApi
-        this.socketApi.startPinging(this.props.user.userId)
 
-        // Refresh list of users each time a user enters or leaves, or each time a user
-        // disconnects (i.e. if client crashes). Disconnect events will lag behind other
-        // events since they rely on the flask-socketio's heartbeat system.
-        const onSocketEvent = room => {
-            if (room === this.state.room) {
-                this.fetchUsersForRoom(room)
-            }
-        }
-        this.socketApi.on('user-left-room', onSocketEvent.bind(this))
-        this.socketApi.on('user-entered-room', onSocketEvent.bind(this))
-        this.socketApi.on('user-disconnected', this.fetchUsersForRoom.bind(this))
+        this.socketApi = new WebSocketApi()
+        this.socketApi.startPinging(this.props.user.userId)
+        this.socketApi.on('user-event', this.props.updateUsers.bind(this))
     }
 
-    async fetchUsersForRoom(room) {
-        const { success, users } = await this.httpApi.getUsers(room || this.state.room)
+    async fetchUsers() {
+        const { success, users } = await this.httpApi.getUsers()
         if (success) {
-            this.setState({ users })
+            this.props.updateUsers(users)
         }
     }
 
     componentDidMount() {
-        this.fetchUsersForRoom(this.state.room)
+        this.fetchUsers()
     }
 
     getRoomData() {
@@ -91,7 +82,7 @@ class Room extends Component {
         */
         const roomData = this.getRoomData()
         const jitsiData = {
-            displayName: this.props.user.displayName,
+            displayName: this.props.user.username,
             avatar: this.props.user.avatar,
             roomName: roomData.name,
             muteRoom: roomData.muteRoom,
@@ -137,13 +128,12 @@ class Room extends Component {
     updateRoom(room) {
         // Leave current room
         this.clearBackground()
-        this.socketApi.leaveRoom(this.props.user.userId, this.state.room)
+        this.socketApi.leaveRoom(this.props.user, this.state.room)
 
         // Go to new room, but don't open the door for rooms that have doors
         const entered = !this.roomTypesWithDoors[this.props.rooms[room].type]
         this.setState({ room, entered })
         this.props.updateCurrentRoom({ room, entered })
-        this.fetchUsersForRoom(room)
 
         // reset door anim
         const door = document.getElementById('door')
@@ -161,6 +151,7 @@ class Room extends Component {
         } else {
             this.updateRoom(room)
         }
+        this.setState({ showMap: false })
     }
 
     onEnterRoom() {
@@ -171,29 +162,34 @@ class Room extends Component {
             room: this.state.room,
             entered: true 
         })
-        this.socketApi.enterRoom(this.props.user.userId, this.state.room)
+        this.socketApi.enterRoom(this.props.user, this.state.room)
     }
 
     handleBeforeUnload() {
         // Update server if user closes tab or refreshes
-        this.socketApi.leaveRoom(this.props.user.userId, this.state.room)
+        this.socketApi.leaveRoom(this.props.user, this.state.room)
+    }
+
+    handleOpenMap() {
+        this.setState({ showMap: true })
+    }
+
+    handleCloseMap() {
+        this.setState({ showMap: false })
     }
 
     render() {
         const room = this.props.rooms[this.state.room]
 
         if (room.type === 'redirect') {
-            this.socketApi.enterRoom(this.props.user.userId, this.state.room)
+            this.socketApi.enterRoom(this.props.user, this.state.room)
             return <Redirect to={room.route} />
         }
 
-        if (room.type === 'map') {
-            return <Map onRoomClick={this.onSwitchRoom.bind(this)}></Map>
-        }
-
+        const userList = this.props.users[this.state.room] || []
         const content = this.state.entered ?
             this.getRoomContent() :
-            <Door room={room} users={this.state.users} tintColor={room.doorTint} onClick={this.onEnterRoom.bind(this)}></Door>
+            <Door room={room} users={userList} tintColor={room.doorTint} onClick={this.onEnterRoom.bind(this)}></Door>
 
         const roomClass = this.state.entered ? "room entered" : "room"
 
@@ -201,6 +197,9 @@ class Room extends Component {
         const visitedRooms = Object.values(this.props.visited).filter(x => x).length
         const isMapUnlocked = _.has(this.roomTypesWithMap, room.type) && (visitedRooms >= mapUnlockThreshold)
         const showMapTooltip = isMapUnlocked && visitedRooms == mapUnlockThreshold
+
+        // Allows modal to have access to react components and state
+        Modal.setAppElement('.app')
 
         return (
             <div className={roomClass}>
@@ -212,16 +211,22 @@ class Room extends Component {
                 <Navigation
                     directions={room.directions}
                     onClick={this.onSwitchRoom.bind(this)}
-                    showMap={isMapUnlocked}
+                    showMapButton={isMapUnlocked}
                     showMapTooltip={showMapTooltip}
-                    >
-                </Navigation>
+                    handleOpenMap={this.handleOpenMap.bind(this)}></Navigation>
                 <Beforeunload onBeforeunload={this.handleBeforeUnload.bind(this)} />
+                <Modal
+                    isOpen={this.state.showMap}
+                    onAfterOpen={this.handleOpenMap.bind(this)}
+                    onRequestClose={this.handleCloseMap.bind(this)}>
+                        <Map onRoomClick={this.onSwitchRoom.bind(this)}></Map>
+                </Modal>
             </div>
         )
     }
 }
 
 export default connect(state => state, {
+    updateUsers: reducers.updateUsersActionCreator,
     updateCurrentRoom: reducers.updateCurrentRoomActionCreator
 })(Room)

--- a/app/client/jsx/UserList.jsx
+++ b/app/client/jsx/UserList.jsx
@@ -16,7 +16,7 @@ export default props => {
     return (
         <div className="user-list">
             {users.map(user => {
-                const [ type, color ] = user.avatar.split('-')
+                const { type, color } = user.avatar
                 const imgClass = isPrivate ? 'private' : ''
                 const username = isPrivate ? 'anonymous' : user.username
 

--- a/app/client/jsx/WebAPI.jsx
+++ b/app/client/jsx/WebAPI.jsx
@@ -29,12 +29,12 @@ export class WebSocketApi {
         }, PING_INTERVAL_MS)
     }
 
-    enterRoom(userId, room) {
-        this.socket.emit('enter-room', { user_id: userId, room })
+    enterRoom(user, room) {
+        this.socket.emit('enter-room', { user, room })
     }
 
-    leaveRoom(userId, room) {
-        this.socket.emit('leave-room', { user_id: userId, room })
+    leaveRoom(user, room) {
+        this.socket.emit('leave-room', { user, room })
     }
 }
 
@@ -55,11 +55,10 @@ export class HttpApi {
         }
     }
 
-    async getUsers(room=null) {
-        /* Only gets active users for the given room, or all active users */
+    async getUsers() {
+        /* Fetches list of active users, mapped to room */
         try {
-            const params = room ? `/${room}` : ''
-            const request = `${url}/users${params}`
+            const request = `${url}/users`
             const response = await axios.get(request)
             return { success: true, users: response.data }
         } catch (err) {

--- a/app/client/jsx/Welcome.jsx
+++ b/app/client/jsx/Welcome.jsx
@@ -10,15 +10,14 @@ class Welcome extends Component {
     constructor(props) {
         super(props)
         this.state = {
-            displayName: null,
+            username: null,
             avatar: null,
             redirect: null
         }
         this.httpApi = new HttpApi()
-        this.props.connectToSocket()
     }
 
-    async componentDidMount() {
+    async fetchRooms() {
         const { success, rooms } = await this.httpApi.getRooms()
         if (success) {
             this.props.addRooms(rooms)
@@ -39,8 +38,12 @@ class Welcome extends Component {
         })
     }
 
-    handleDisplayNameChange(event) {
-        this.setState({ displayName: event.target.value })
+    componentDidMount() {
+        this.fetchRooms()
+    }
+
+    handleUsernameChange(event) {
+        this.setState({ username: event.target.value })
     }
 
     handleAvatarSelect(selection) {
@@ -48,12 +51,11 @@ class Welcome extends Component {
     }
 
     async handleReady() {
-        console.log(this.state)
-        const response = await this.httpApi.join(this.state.displayName, this.state.avatar)
+        const response = await this.httpApi.join(this.state.username, this.state.avatar)
         if (response.success) {
-            const { displayName, avatar } = this.state
+            const { username, avatar } = this.state
             this.props.updateUser({
-                displayName,
+                username,
                 avatar,
                 userId: response.userId
             })
@@ -84,9 +86,9 @@ class Welcome extends Component {
         let name_opacity = 'form-fade'
         let avatar_opacity = 'form-fade'
         let party_opacity = 'form-fade-party'
-        if (this.state.displayName === null) { name_opacity = 'form' }
-        if (this.state.displayName) { avatar_opacity = 'form' }
-        if (this.state.displayName && this.state.avatar) { party_opacity = 'form-party' }
+        if (this.state.username === null) { name_opacity = 'form' }
+        if (this.state.username) { avatar_opacity = 'form' }
+        if (this.state.username && this.state.avatar) { party_opacity = 'form-party' }
 
         return (
             <div className="vestibule">
@@ -94,9 +96,9 @@ class Welcome extends Component {
                 <div className='serif'>You've met with a terrible fate, haven't you?</div>
                 <h1>Cabin Weekend is Dead. Long Live Cabin Fever.</h1>
                 <img className='splash' src='./js/images/cabinfeverhighres.png'/>
-                <input style={text_entry} autoComplete="off" className={name_opacity} type="text" placeholder="Name" name="name" minLength="1" onChange={this.handleDisplayNameChange.bind(this)}/><br/>
+                <input style={text_entry} autoComplete="off" className={name_opacity} type="text" placeholder="Name" name="name" minLength="1" onChange={this.handleUsernameChange.bind(this)}/><br/>
                 <PuckSelect opacity={avatar_opacity} handleSelect={this.handleAvatarSelect.bind(this)} />
-                <input id='button' className={party_opacity} type="button" onClick={this.handleReady.bind(this)} value="Party" disabled={!this.state.displayName||!this.state.avatar} />
+                <input id='button' className={party_opacity} type="button" onClick={this.handleReady.bind(this)} value="Party" disabled={!this.state.username||!this.state.avatar} />
             </div>
         )
 
@@ -108,6 +110,5 @@ export default connect(
     {
         addRooms: reducers.addRoomsActionCreator,
         updateUser: reducers.updateUserActionCreator,
-        connectToSocket: reducers.connectSocketActionCreator,
         updateCurrentRoom: reducers.updateCurrentRoomActionCreator
      })(Welcome)

--- a/app/client/jsx/reducers.jsx
+++ b/app/client/jsx/reducers.jsx
@@ -1,19 +1,29 @@
+import _ from 'lodash'
 import { handleActions } from 'redux-actions'
-import { WebSocketApi } from './WebAPI.jsx'
 
 const ADD_ROOMS = 'ADD_ROOMS'
 const UPDATE_USER = 'UPDATE_USER'
-const CONNECT_SOCKET = 'CONNECT_SOCKET'
+const UPDATE_USERS = 'UPDATE_USERS'
 const UPDATE_CURRENT_ROOM = 'UPDATE_CURRENT_ROOM'
 const UPDATE_AUDIO_MUTED = 'UPDATE_AUDIO_MUTED'
 const UPDATE_VIDEO_MUTED = 'UPDATE_VIDEO_MUTED'
 
+/*
+* This is the global state.
+*   user: userId, username, avatar type/color
+*   rooms: roomId->room definition mapping
+*   users: roomId->userlist mapping, gets updated by websockets
+*   currentRoom: room, entered
+*   visited: map of which rooms user has visited
+*   isAudioMuted: whether or not the user currently has audio muted
+*   isVideoMuted: whether or not the user currently has video muted
+*/
 const initialState = {
-    rooms: {},
     user: {},
-    currentRoom: '',
+    rooms: {},
+    users: {},
+    currentRoom: {},
     visited: {},
-    socketApi: null,
     isAudioMuted: false,
     isVideoMuted: false
 }
@@ -22,14 +32,12 @@ function addRoomsAction(state, rooms) {
     return Object.assign({}, state, rooms)
 }
 
-function updateUserAction(state, user) {
-  console.log(state, ' ', user)
-    return Object.assign({}, state, user)
+function updateUsersAction(state, users) {
+    return Object.assign({}, state, users)
 }
 
-function connectSocketAction(state) {
-    const socketApi = new WebSocketApi()
-    return Object.assign({}, state, { socketApi })
+function updateUserAction(state, user) {
+    return Object.assign({}, state, user)
 }
 
 function updateCurrentRoomAction(state, currentRoom) {
@@ -57,8 +65,9 @@ export default {
         type: UPDATE_USER,
         user
     }),
-    connectSocketActionCreator: () => ({
-        type: CONNECT_SOCKET
+    updateUsersActionCreator: users => ({
+        type: UPDATE_USERS,
+        users
     }),
     updateCurrentRoomActionCreator: currentRoom => ({
         type: UPDATE_CURRENT_ROOM,
@@ -76,7 +85,7 @@ export default {
     reducer: handleActions({
         [ADD_ROOMS]: addRoomsAction,
         [UPDATE_USER]: updateUserAction,
-        [CONNECT_SOCKET]: connectSocketAction,
+        [UPDATE_USERS]: updateUsersAction,
         [UPDATE_CURRENT_ROOM]: updateCurrentRoomAction,
         [UPDATE_AUDIO_MUTED]: updateAudioMutedAction,
         [UPDATE_VIDEO_MUTED]: updateVideoMutedAction

--- a/app/client/package.json
+++ b/app/client/package.json
@@ -22,6 +22,7 @@
         "lodash": "4.17.15",
         "mini-css-extract-plugin": "^0.9.0",
         "react-beforeunload": "^2.2.0",
+        "react-modal": "^3.11.2",
         "react-reveal": "^1.2.2",
         "sass": "^1.26.3",
         "socket.io": "^2.3.0",

--- a/app/client/styles/themes/_default.scss
+++ b/app/client/styles/themes/_default.scss
@@ -9,3 +9,11 @@ body {
 	background-attachment: fixed;
 	min-height: 100vh;
 }
+
+.ReactModal__Content {
+	border: none !important;
+	background: $background-color !important;
+}
+.ReactModal__Overlay {
+	background: lighten($background-color, 20%) !important;
+}

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -11,21 +11,13 @@ def join():
     user = User.create(**params)
     return jsonify(user.to_json())
 
-@main.route('/users/<room>')
-def get_users(room):
-    # NOTE uncomment this to test with mock data
-    # basedir = current_app.config.get('BASE_DIR')
-    # users = json.load(open(os.path.join(basedir, 'mock_map_data.json')))['data']
-    # return jsonify(list(filter(lambda user: user['room'] == room, users)))
-    return jsonify(list(User.get_active_users_for_room(room)))
-
 @main.route('/users')
-def get_all_users():
+def get_users():
     # NOTE uncomment this to test map with mock data
     # basedir = current_app.config.get('BASE_DIR')
     # users = json.load(open(os.path.join(basedir, 'mock_map_data.json')))['data']
     # return jsonify(users)
-    return jsonify(list(User.get_active_users()))
+    return jsonify(User.get_active_users_by_room())
 
 @main.route('/rooms')
 def get_rooms():

--- a/app/rooms.json
+++ b/app/rooms.json
@@ -479,9 +479,5 @@
         "name": "Bye",
         "type": "redirect",
         "route": "/bye"
-    },
-    "map": {
-        "name": "Map",
-        "type": "map"
     }
 }


### PR DESCRIPTION
The client now:

1. Sends a request once after the user logs in to fetch the current global state of rooms / users per room
2. Uses websockets to sync the global client state with the global server state (only active users, filtering by `user.last_seen`). For example: if a user leaves a room, this will send a socket update to flask, which updates the user location table and then broadcasts a message to all clients with a message containing the full state of active users. We use full state instead of diffs as a failsafe to prevent drift between client & server. 
3. Turns the map into a modal, so that you no longer have to leave the room to see the map.
4. Turns `user.avatar` into an object `{ type, color }` instead of an array so that we can semantically access the values by name instead of index. I was running into some errors with clashing `user.avatar` types in the client - sometimes it was showing up as `normal-puck` and other times `['normal', 'puck']`, so I decided to normalize this data structure.