### PR TITLE
Remove redundant GET Users query

### DIFF
--- a/app/client/jsx/Room.jsx
+++ b/app/client/jsx/Room.jsx
@@ -11,7 +11,7 @@ import Map from './Map.jsx'
 import Door from './Door.jsx'
 import Adventure from './Adventure.jsx'
 import Navigation from './Navigation.jsx'
-import { HttpApi, WebSocketApi } from './WebAPI.jsx'
+import { WebSocketApi } from './WebAPI.jsx'
 
 class Room extends Component {
     /*
@@ -50,22 +50,9 @@ class Room extends Component {
             showMap: false
         }
 
-        this.httpApi = new HttpApi()
-
         this.socketApi = new WebSocketApi()
         this.socketApi.startPinging(this.props.user.userId)
         this.socketApi.on('user-event', this.props.updateUsers.bind(this))
-    }
-
-    async fetchUsers() {
-        const { success, users } = await this.httpApi.getUsers()
-        if (success) {
-            this.props.updateUsers(users)
-        }
-    }
-
-    componentDidMount() {
-        this.fetchUsers()
     }
 
     getRoomData() {

--- a/app/client/jsx/WebAPI.jsx
+++ b/app/client/jsx/WebAPI.jsx
@@ -54,18 +54,7 @@ export class HttpApi {
             return { success: false }
         }
     }
-
-    async getUsers() {
-        /* Fetches list of active users, mapped to room */
-        try {
-            const request = `${url}/users`
-            const response = await axios.get(request)
-            return { success: true, users: response.data }
-        } catch (err) {
-            return { success: false }
-        }
-    }
-
+    
     async getRooms() {
         /* Fetches room definition, including adventure rooms */
         try {

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -11,14 +11,6 @@ def join():
     user = User.create(**params)
     return jsonify(user.to_json())
 
-@main.route('/users')
-def get_users():
-    # NOTE uncomment this to test map with mock data
-    # basedir = current_app.config.get('BASE_DIR')
-    # users = json.load(open(os.path.join(basedir, 'mock_map_data.json')))['data']
-    # return jsonify(users)
-    return jsonify(User.get_active_users_by_room())
-
 @main.route('/rooms')
 def get_rooms():
     basedir = current_app.config.get('BASE_DIR')


### PR DESCRIPTION
Since the `on-connect` socket event now sends the global state, the initial fetch for the global state is now redundant.