### PR TITLE
Fix bug where avatar & name were not showing up in jitsi video

### DIFF
--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -137,8 +137,8 @@ style.appendChild(document.createTextNode(css));
             window.api.addEventListener('videoConferenceJoined', () => {
                 this.makeJitsiTransparent()
                 this.hideSpinner()
-                const [ avatarType, avatarColor ] = this.props.jitsiData.avatar
-                const avatarUrl = Avatars[avatarType][avatarColor]
+                const { type, color } = this.props.jitsiData.avatar
+                const avatarUrl = Avatars[type][color]
                 const commands = {
                     displayName: this.props.jitsiData.displayName,
                     avatarUrl,


### PR DESCRIPTION
The code was actually erroring before we could send jitsi any custom commands, including avatar, display name, and audio/video settings, so it wasn't updating those settings. As a consequence, it was relying on cached avatar/usernames, which is why we were sometimes seeing old ones.