### PR TITLE
Improve DB relationships and queries

### DIFF
--- a/app/jitsi/events.py
+++ b/app/jitsi/events.py
@@ -27,7 +27,7 @@ def on_ping(message):
 
 @socketio.on('leave-room')
 def on_leave_room(message):
-    User.leave_room(message['user']['userId'], message['room'])
+    User.leave_room(message['user']['userId'])
     broadcast_state()
 
 

--- a/app/jitsi/events.py
+++ b/app/jitsi/events.py
@@ -27,7 +27,7 @@ def on_ping(message):
 
 @socketio.on('leave-room')
 def on_leave_room(message):
-    User.leave_room(message['user']['userId'])
+    User.leave_room(message['user']['userId'], message['room'])
     broadcast_state()
 
 

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -50,9 +50,15 @@ class User(db.Model, SerializerMixin):
     @classmethod
     def leave_room(cls, user_id, room_name):
         user = User.query.filter_by(id=user_id).first()
+
+        if not user.room:
+            # Navigated from one hallway to another.
+            return
+
         if user.room.name != room_name:
             logger.warning(f"User {user.id} ({user.username}) tried to leave room {room_name} but was in room {room.name}")
             return
+
         user.room = None
         db.session.commit()
 

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -1,6 +1,7 @@
 from . import db
 from datetime import datetime
 from collections import defaultdict
+from sqlalchemy import UniqueConstraint
 from sqlalchemy_serializer import SerializerMixin
 from sqlalchemy.ext.hybrid import hybrid_property
 
@@ -102,6 +103,10 @@ class Room(db.Model, SerializerMixin):
 
 class UserRoomState(db.Model, SerializerMixin):
     __tablename__ = 'user_room_states'
+    __table_args__ = (
+        UniqueConstraint('user_id', 'room_id', name='_unique_user_room'),
+    )
+
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('users.id'))
     room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'))

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -13,7 +13,7 @@ class User(db.Model, SerializerMixin):
     avatar = db.Column(db.String())
     last_seen = db.Column(db.Integer, default=lambda: datetime.utcnow().timestamp())
 
-    room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'))
+    room_id = db.Column(db.Integer, db.ForeignKey('room.id'))
     room = relationship('Room', backpopulates='users')
 
     @hybrid_property

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -21,7 +21,7 @@ class User(db.Model, SerializerMixin):
     last_seen = db.Column(db.Integer, default=lambda: datetime.utcnow().timestamp())
 
     room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'))
-    room = relationship('Room', back_populates='users')
+    room = relationship('Room')
 
     @hybrid_property
     def is_active(self):
@@ -104,8 +104,6 @@ class Room(db.Model, SerializerMixin):
     name = db.Column(db.String(100), unique=True, index=True)
     room_type = db.Column(db.String(50))
 
-    users = relationship('User', back_populates='room')
-
     def __repr__(self):
         return 'Room {0}'.format(self.name)
 
@@ -126,8 +124,8 @@ class UserRoomState(db.Model, SerializerMixin):
         user_room_state = cls.query.filter_by(user_id=user_id, room_id=room_id).one_or_none()
         if not user_room_state:
             user_room_state = cls(user_id=user_id, room_id=room_id)
-            session.add(user_room_state)
-            session.commit()
+            db.session.add(user_room_state)
+            db.session.commit()
         return user_room_state
 
     def __repr__(self):

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -4,8 +4,9 @@ from . import db
 from collections import defaultdict
 from datetime import datetime
 from sqlalchemy import UniqueConstraint
-from sqlalchemy_serializer import SerializerMixin
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.orm import relationship
+from sqlalchemy_serializer import SerializerMixin
 
 
 USER_TIMEOUT = 30
@@ -19,8 +20,8 @@ class User(db.Model, SerializerMixin):
     avatar = db.Column(db.String())
     last_seen = db.Column(db.Integer, default=lambda: datetime.utcnow().timestamp())
 
-    room_id = db.Column(db.Integer, db.ForeignKey('room.id'))
-    room = relationship('Room', backpopulates='users')
+    room_id = db.Column(db.Integer, db.ForeignKey('rooms.id'))
+    room = relationship('Room', back_populates='users')
 
     @hybrid_property
     def is_active(self):
@@ -50,7 +51,7 @@ class User(db.Model, SerializerMixin):
     def leave_room(cls, user_id, room_name):
         user = User.query.filter_by(id=user_id).first()
         if user.room.name != room_name:
-            logger.warning(f"User {user.id} ({user.username}) tried to leave room {room_name} but was in room {room.name}"))
+            logger.warning(f"User {user.id} ({user.username}) tried to leave room {room_name} but was in room {room.name}")
             return
         user.room = None
         db.session.commit()
@@ -103,7 +104,7 @@ class Room(db.Model, SerializerMixin):
     name = db.Column(db.String(100), unique=True, index=True)
     room_type = db.Column(db.String(50))
 
-    users = relationship('User', backpopulates='room')
+    users = relationship('User', back_populates='room')
 
     def __repr__(self):
         return 'Room {0}'.format(self.name)

--- a/app/jitsi/models.py
+++ b/app/jitsi/models.py
@@ -1,11 +1,16 @@
+import logging
+
 from . import db
-from datetime import datetime
 from collections import defaultdict
+from datetime import datetime
 from sqlalchemy import UniqueConstraint
 from sqlalchemy_serializer import SerializerMixin
 from sqlalchemy.ext.hybrid import hybrid_property
 
+
 USER_TIMEOUT = 30
+logger = logging.getLogger(__name__)
+
 
 class User(db.Model, SerializerMixin):
     __tablename__ = 'users'
@@ -42,8 +47,11 @@ class User(db.Model, SerializerMixin):
         return user
 
     @classmethod
-    def leave_room(cls, user_id):
+    def leave_room(cls, user_id, room_name):
         user = User.query.filter_by(id=user_id).first()
+        if user.room.name != room_name:
+            logger.warning(f"User {user.id} ({user.username}) tried to leave room {room_name} but was in room {room.name}"))
+            return
         user.room = None
         db.session.commit()
 


### PR DESCRIPTION
Addresses #100.

- Adds a one-to-many `relationship()` property between User and Room to give us automagic joins and more efficient queries
- Removes the User-Room join table `UserLocation` - shouldn't need it in a one-to-many relationship (https://docs.sqlalchemy.org/en/13/orm/basic_relationships.html)
- Modifies `get_active_users_by_room()` to make use of changes