### PR TITLE
Remove baseUrl from config

### DIFF
--- a/app/client/jsx/Config.jsx
+++ b/app/client/jsx/Config.jsx
@@ -13,8 +13,10 @@ try {
 // live config is built by adding the rooms config and one of dev or prod config to base config
 // values in prodConfig override values in baseConfig when not running locally
 
-const hostname = window && window.location && window.location.hostname
-const developmentMode = hostname && hostname.includes('localhost')
+const href = window && window.location && window.location.href
+const developmentMode = href && href.includes('localhost')
 const config = Object.assign(baseConfig, !developmentMode ? prodConfig : devConfig)
+
+config.baseUrl = href
 
 export default Object.assign(config, overrideConfig)

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -1,5 +1,4 @@
 {
-	"baseUrl": "http://localhost:3000",
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true,

--- a/app/config/development.json
+++ b/app/config/development.json
@@ -1,5 +1,4 @@
 {
-	"baseUrl": "http://localhost:3000",
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true

--- a/app/config/overrides/cabin.config.json
+++ b/app/config/overrides/cabin.config.json
@@ -1,5 +1,4 @@
 {
-	"baseUrl": "http://localhost:3000",
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true,

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,4 +1,3 @@
 {
-	"baseUrl": "https://party.gbre.org/",
 	"debug": false
 }


### PR DESCRIPTION
I don't think we need localhost:port or the production url hardcoded in the config since we can just introspect it from the window.