### PR TITLE
Genericize map stats

### DIFF
--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -138,7 +138,7 @@ style.appendChild(document.createTextNode(css));
                 this.makeJitsiTransparent()
                 this.hideSpinner()
                 const { type, color } = this.props.jitsiData.avatar
-                const avatarUrl = config.avatars[type][color]
+                const avatarUrl = Config.avatars[type][color]
                 const commands = {
                     displayName: this.props.jitsiData.displayName,
                     avatarUrl,

--- a/app/client/jsx/Map.jsx
+++ b/app/client/jsx/Map.jsx
@@ -78,27 +78,22 @@ class Map extends Component {
             }
         ]
         .filter(({ key }) => config[key].display)
-        .map(({ key, count }) => ({
-            text: config[key].text.replace('{0}', count),
-            emoji: config[key].emoji
-        }))
+        .map(({ key, count }) => (
+            config[key].text.replace('{count}', count)
+        ))
 
-        config.additionalStats.forEach(({ text, match, emoji }) => {
+        config.additionalStats.forEach(({ text, match }) => {
             const rooms = _.isArray(match) ?
                 _.intersection(Object.keys(users), match) :
                 Object.keys(users).filter(room => new RegExp(match).test(room))
             const count = _.sumBy(rooms, room => users[room].length)
-            mapStats.push({
-                text: text.replace('{0}', count),
-                emoji
-            })
+            mapStats.push(text.replace('{count}', count))
         })
 
         return (
             <div className="map-stats">
-                {mapStats.map(({ text, emoji}, index) => (
+                {mapStats.map((text, index) => (
                     <div key={`stat-${index}`} className="map-stat-column">
-                        <span className="map-stat-emoji">{emoji}</span>
                         {text}
                     </div>
                 ))}

--- a/app/client/jsx/Map.jsx
+++ b/app/client/jsx/Map.jsx
@@ -83,7 +83,6 @@ class Map extends Component {
             emoji: config[key].emoji
         }))
 
-        // TODO: g flag?
         config.additionalStats.forEach(({ text, match, emoji }) => {
             const rooms = _.isArray(match) ?
                 _.intersection(Object.keys(users), match) :

--- a/app/client/styles/pages/_map.scss
+++ b/app/client/styles/pages/_map.scss
@@ -27,11 +27,6 @@
 
             .map-stat-column {
                 margin-right: 25px;
-
-                .map-stat-emoji {
-                    font-size: large;
-                    margin-right: 5px;
-                }
             }
         }
 

--- a/app/config.py
+++ b/app/config.py
@@ -22,6 +22,7 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     BASE_DIR = basedir
     MESSAGE_QUEUE = 'amqp://localhost:5672'
+    # MESSAGE_QUEUE = None
     CONFIG_PATHS = [os.path.join(configdir, file) for file in ['base.json', 'rooms.json', 'adventures.json']]
     OVERRIDE_PATHS = [os.path.join(overridedir, file) for file in ['config.json', 'rooms.json']]
 

--- a/app/config.py
+++ b/app/config.py
@@ -21,7 +21,8 @@ class Config:
     # To silence deprecation warning
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     BASE_DIR = basedir
-    MESSAGE_QUEUE = 'amqp://localhost:5672'
+    # MESSAGE_QUEUE = 'amqp://localhost:5672'
+    MESSAGE_QUEUE = None
     CONFIG_PATHS = [os.path.join(configdir, file) for file in ['base.json', 'rooms.json', 'adventures.json']]
     OVERRIDE_PATHS = [os.path.join(overridedir, file) for file in ['config.json', 'rooms.json']]
 

--- a/app/config.py
+++ b/app/config.py
@@ -21,8 +21,7 @@ class Config:
     # To silence deprecation warning
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     BASE_DIR = basedir
-    # MESSAGE_QUEUE = 'amqp://localhost:5672'
-    MESSAGE_QUEUE = None
+    MESSAGE_QUEUE = 'amqp://localhost:5672'
     CONFIG_PATHS = [os.path.join(configdir, file) for file in ['base.json', 'rooms.json', 'adventures.json']]
     OVERRIDE_PATHS = [os.path.join(overridedir, file) for file in ['config.json', 'rooms.json']]
 

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -36,18 +36,7 @@
 				"text": "{0} roaming",
 				"emoji": "🌓"
 			},
-			"additionalStats": [
-				{
-					"text": "{0} doing activity",
-					"match": ".*Room",
-					"emoji": "🎯"
-				},
-				{
-					"text": "{0} in closet",
-					"match": ["closet"],
-					"emoji": "🗝"
-				}
-			]
+			"additionalStats": []
 		}
 	}
 }

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -18,5 +18,36 @@
 	  }
 	},
 	"specialAvatars": {
+	},
+	"map": {
+		"stats": {
+			"numberInHouse": {
+				"display": true,
+				"text": "{0} in house",
+				"emoji": "🏚️"
+			},
+			"numberInRooms": {
+				"display": true,
+				"text": "{0} in rooms",
+				"emoji": "🚪"
+			},
+			"numberInHallways": {
+				"display": true,
+				"text": "{0} roaming",
+				"emoji": "🌓"
+			},
+			"additionalStats": [
+				{
+					"text": "{0} doing activity",
+					"match": ".*Room",
+					"emoji": "🎯"
+				},
+				{
+					"text": "{0} in closet",
+					"match": ["closet"],
+					"emoji": "🗝"
+				}
+			]
+		}
 	}
 }

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -23,18 +23,15 @@
 		"stats": {
 			"numberInHouse": {
 				"display": true,
-				"text": "{0} in house",
-				"emoji": "🏚️"
+				"text": "🏚️ {count} in house"
 			},
 			"numberInRooms": {
 				"display": true,
-				"text": "{0} in rooms",
-				"emoji": "🚪"
+				"text": "🚪 {count} in rooms"
 			},
 			"numberInHallways": {
 				"display": true,
-				"text": "{0} roaming",
-				"emoji": "🌓"
+				"text": "🌓 {count} roaming"
 			},
 			"additionalStats": []
 		}

--- a/app/config/overrides/cabin.config.json
+++ b/app/config/overrides/cabin.config.json
@@ -54,24 +54,20 @@
 		"stats": {
 			"numberInHouse": {
 				"display": true,
-				"text": "{0} in cabin",
-				"emoji": "🏚️"
+				"text": "🏚️ {count} in cabin"
 			},
 			"numberInHallways": {
 				"display": true,
-				"text": "{0} roaming",
-				"emoji": "🌓"
+				"text": "🌓 {count} roaming"
 			},
 			"numberInRooms": {
 				"display": true,
-				"text": "{0} partying",
-				"emoji": "🎉"
+				"text": "🎉 {count} partying"
 			},
 			"additionalStats": [
 				{
-					"text": "{0} taking bathroom break",
-					"match": ["bathroom"],
-					"emoji": "🛁"
+					"text": "🛁 {0} taking bathroom break",
+					"match": ["bathroom"]
 				}
 			]
 		}

--- a/app/config/overrides/cabin.config.json
+++ b/app/config/overrides/cabin.config.json
@@ -51,12 +51,19 @@
 	  }
 	},
 	"map": {
-		"additionalStats": [
-			{
-				"text": "{0} taking bathroom break",
-				"match": ["bathroom"],
-				"emoji": "🛁"
-			}
-		]
+		"stats": {
+			"numberInRooms": {
+				"display": true,
+				"text": "{0} partying",
+				"emoji": "🎉"
+			},
+			"additionalStats": [
+				{
+					"text": "{0} taking bathroom break",
+					"match": ["bathroom"],
+					"emoji": "🛁"
+				}
+			]
+		}
 	}
 }

--- a/app/config/overrides/cabin.config.json
+++ b/app/config/overrides/cabin.config.json
@@ -52,6 +52,16 @@
 	},
 	"map": {
 		"stats": {
+			"numberInHouse": {
+				"display": true,
+				"text": "{0} in cabin",
+				"emoji": "🏚️"
+			},
+			"numberInHallways": {
+				"display": true,
+				"text": "{0} roaming",
+				"emoji": "🌓"
+			},
 			"numberInRooms": {
 				"display": true,
 				"text": "{0} partying",

--- a/app/config/overrides/cabin.config.json
+++ b/app/config/overrides/cabin.config.json
@@ -49,5 +49,14 @@
 	    "red": "./js/images/puck/thumb-red.png",
 	    "orange": "./js/images/puck/thumb-orange.png"
 	  }
+	},
+	"map": {
+		"additionalStats": [
+			{
+				"text": "{0} taking bathroom break",
+				"match": ["bathroom"],
+				"emoji": "🛁"
+			}
+		]
 	}
 }


### PR DESCRIPTION
Config now controls the stats displayed on the map. The three default stats (# in house, # in rooms, # roaming) can be switched on or off and the text/emoji can be customized. More stats can be added in the `additionalStats` list, which counts up users in rooms matching a given list of rooms or a regular expression. 

Let's say the following additional stats are added:
```json
"additionalStats": [
	{
		"text": "{0} doing activity",
		"match": ".*Room",
		"emoji": "🎯"
	},
	{
		"text": "{0} in closet",
		"match": ["closet"],
		"emoji": "🗝"
	}
]
```

The first stat will match on any room key ending in `Room`, and the second will match on `closet`, resulting in the following header, where the user is currently in the Game Room:

![Screen Shot 2020-05-31 at 1 57 28 PM](https://user-images.githubusercontent.com/4405597/83359197-b94b9d00-a346-11ea-8017-926360e28b30.png)