### PR TITLE
Modify specification of Jitsi server URL and noSSL option for configurability and to work w/ docker

### DIFF
--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -84,9 +84,9 @@ class JitsiVideo extends Component {
                 toolbarButtons = _.without(this.toolbarButtons, 'microphone')
             }
 
-            let domain = `${window.location.host}/jitsi/`
-            if (Config.jitsiServerUrl) {
-                domain = Config.jitsiServerUrl
+            let domain = Config.jitsiServerUrl
+            if (Config.overrideJitsiServerUrlWithWindowHost) {
+                domain = `${window.location.host}/jitsi/`
             }
 
             const options = {

--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -86,7 +86,7 @@ class JitsiVideo extends Component {
 
             let domain = Config.jitsiServerUrl
             if (Config.overrideJitsiServerUrlWithWindowHost) {
-                domain = `${window.location.host}/jitsi/`
+                domain = `${window.location.host}/jitsi`
             }
 
             const options = {

--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -84,9 +84,11 @@ class JitsiVideo extends Component {
                 toolbarButtons = _.without(this.toolbarButtons, 'microphone')
             }
 
-            const domain = 'party.gbre.org/jitsi/'
+            // const domain = 'party.gbre.org/jitsi/'
             // const domain = 'meet.jit.si';
+            const domain = `${window.location.host}/jitsi/`
             const options = {
+                noSSL: true,
                 roomName: this.props.jitsiData.roomName,
                 parentNode: document.getElementById('jitsi-container'),
                 interfaceConfigOverwrite: {

--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -84,9 +84,11 @@ class JitsiVideo extends Component {
                 toolbarButtons = _.without(this.toolbarButtons, 'microphone')
             }
 
-            // const domain = 'party.gbre.org/jitsi/'
-            // const domain = 'meet.jit.si';
-            const domain = `${window.location.host}/jitsi/`
+            let domain = `${window.location.host}/jitsi/`
+            if (Config.jitsiServerUrl) {
+                domain = Config.jitsiServerUrl
+            }
+
             const options = {
                 noSSL: true,
                 roomName: this.props.jitsiData.roomName,

--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -90,7 +90,7 @@ class JitsiVideo extends Component {
             }
 
             const options = {
-                noSSL: true,
+                noSSL: Config.noJitsiServerSSL,
                 roomName: this.props.jitsiData.roomName,
                 parentNode: document.getElementById('jitsi-container'),
                 interfaceConfigOverwrite: {

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -2,6 +2,7 @@
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"jitsiServerUrl": "meet.jit.si",
+	"overrideJitsiServerUrlWithWindowHost": false,
 	"noJitsiServerSSL": false,
 	"useLocalSessions": true,
 	"welcomePage": {

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -1,6 +1,8 @@
 {
 	"debug": true,
 	"mapUnlockThreshold": 3,
+	"jitsiServerUrl": "meet.jit.si",
+	"noJitsiServerSSL": false,
 	"useLocalSessions": true,
 	"welcomePage": {
 		"avatarSelectionEnabled": true,

--- a/app/config/development.json
+++ b/app/config/development.json
@@ -2,5 +2,5 @@
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true,
-	"jitsiServerUrl": null
+	"noJitsiServerSSL": true
 }

--- a/app/config/development.json
+++ b/app/config/development.json
@@ -2,5 +2,5 @@
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true,
-	"jitsiServerUrl": "meet.jit.si"
+	"jitsiServerUrl": null
 }

--- a/app/config/development.json
+++ b/app/config/development.json
@@ -2,5 +2,6 @@
 	"debug": true,
 	"mapUnlockThreshold": 3,
 	"useLocalSessions": true,
-	"noJitsiServerSSL": true
+	"noJitsiServerSSL": true,
+	"overrideJitsiServerUrlWithWindowHost": true
 }

--- a/app/config/development.json
+++ b/app/config/development.json
@@ -1,5 +1,6 @@
 {
 	"debug": true,
 	"mapUnlockThreshold": 3,
-	"useLocalSessions": true
+	"useLocalSessions": true,
+	"jitsiServerUrl": "meet.jit.si"
 }

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,4 +1,5 @@
 {
 	"debug": false,
-	"noJitsiServerSSL": false
+	"noJitsiServerSSL": false,
+	"overrideJitsiServerUrlWithWindowHost": false
 }

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,5 +1,5 @@
 {
 	"debug": false,
 	"noJitsiServerSSL": false,
-	"overrideJitsiServerUrlWithWindowHost": false
+	"overrideJitsiServerUrlWithWindowHost": true
 }

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,4 +1,4 @@
 {
 	"debug": false,
-	"jitsiServerUrl": "party.gbre.org/jitsi/"
+	"jitsiServerUrl": null
 }

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,3 +1,4 @@
 {
-	"debug": false
+	"debug": false,
+	"jitsiServerUrl": "party.gbre.org/jitsi/"
 }

--- a/app/config/production.json
+++ b/app/config/production.json
@@ -1,4 +1,4 @@
 {
 	"debug": false,
-	"jitsiServerUrl": null
+	"noJitsiServerSSL": false
 }


### PR DESCRIPTION
- move Jitsi server URL to config
- create option to override Jitsi server URL with window.location.host/jitsi
  - use this option on dev and prod
- specify noSSL in config
  - true on dev, false on prod