### PR TITLE
Email a moderator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 app/client/js/bundle*
 app/client/js/styles*
 
+# Email config
+app/email_config.sh
+
 # DB
 app/db.sqlite
 

--- a/app/client/jsx/CustomComponents/CustomComponentExample.jsx
+++ b/app/client/jsx/CustomComponents/CustomComponentExample.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+
+// An example of how to use the custom component plugin system. Custom components are passed a room and can use its API.
+// See https://github.com/morganecf/jitsi-party/pull/139 for a more detailed example of an actual custom component of
+// a "portal" we wanted to use at one point. This one is being used as a modal and accesses a room's handleModalChange
+// function. The PR also shows how we might start to keep ALL of app state in redux (much of it is currently in Room.jsx),
+// so that custom components or plugins can execute actions to effect a change in app state.
+
+
+export default ({ room }) => {
+    const handleEnter = () => {
+        setTimeout(() => {
+            // execute(room, {
+            //     type: 'CHANGE_ROOM',
+            //     nextRoom: 'livingRoom',
+            //     entered: true
+            // })
+            handleDismiss()
+        }, 3000)
+    }
+
+    const handleDismiss = () => {
+        room.handleModalChange(null)
+    }
+
+    return (
+        <div className="example-component">
+            This is an example of a custom component. Do you want to switch rooms?
+            <button onClick={handleEnter}>Yes</button>
+            <button onClick={handleDismiss}>No</button>
+        </div>
+    )
+}

--- a/app/client/jsx/CustomComponents/index.js
+++ b/app/client/jsx/CustomComponents/index.js
@@ -1,0 +1,5 @@
+import CustomComponentExample from './CustomComponentExample.jsx'
+
+export default {
+    CustomComponentExample
+}

--- a/app/client/jsx/EmailForm.jsx
+++ b/app/client/jsx/EmailForm.jsx
@@ -1,17 +1,39 @@
 import React, { useState } from 'react'
 import { HttpApi } from './WebAPI.jsx'
+import Config from './Config.jsx'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import {
+    faCircleNotch,
+    faEnvelope,
+    faExclamationCircle
+} from '@fortawesome/free-solid-svg-icons'
 
 
 export default ({ user }) => {
     const MIN_WORDS = 10
     const MAX_WORDS = 500
 
+    const STATUS = {
+        sending: {
+            label: 'Your message is being sent...',
+            icon: faCircleNotch
+        },
+        succeeded: {
+            label: 'Message sent!',
+            icon: faEnvelope
+        },
+        failed: {
+            label: `Something went wrong sending your message. Please close this box and try again, or email the moderator directly at ${Config.moderation.moderatorEmails[0]}.`,
+            icon: faExclamationCircle
+        }
+    }
+
     const httpApi = new HttpApi()
 
     const [email, setEmail] = useState('')
     const [message, setMessage] = useState('')
-    const [sending, setSending] = useState(false)
     const [sent, setSent] = useState(false)
+    const [status, setStatus] = useState('sending')
 
     const numWords = message.split(/\s+/).length - 1
     const wordCountClass = numWords < MIN_WORDS || numWords === MAX_WORDS ? 'bad-word-count' : ''
@@ -24,32 +46,32 @@ export default ({ user }) => {
     const handleEmailInput = event => setEmail(event.target.value)
     const handleSubmit = async () => {
         // TODO email validation
-        // TODO don't modify inputs while sending
-        setSending(true)
+        setSent(true)
         const { success } = await httpApi.emailModerators(message, email, user)
-        if (success) {
-            setSent(true)
-        }
+        setStatus(success ? 'succeeded' : 'failed')
     }
 
     return sent ?
         (
             <div className="email-form">
-                <div className="email-sent">Message sent!</div>
+                <div className="email-status">
+                    <span className="email-status-icon"><FontAwesomeIcon icon={STATUS[status].icon} spin={status === 'sending'}/></span>
+                    <span className="email-status-label">{STATUS[status].label}</span>
+                </div>
+                {
+                    status === 'failed' ? <section className="original-message">{message}</section> : ''
+                }
             </div>
         ) :
         (
             <div className="email-form">
                 <section className="email-form-instructions">
-                    If you have any questions or concerns, please send us a message and our moderators will address it as soon as possible.
-                    Please include your email address if you want a moderator to contact you back directly. 
+                    {Config.moderation.formDescription}
                 </section>
                 <section className="email-form-message">
                     <div>Your message <span className={wordCountClass}>({numWords} / {MAX_WORDS})</span></div>
                     <textarea
-                        // placeholder={PLACEHOLDER}
                         autoFocus="autofocus"
-                        disabled={sending}
                         value={message}
                         onChange={handleMessageInput}/>
                 </section>
@@ -57,8 +79,8 @@ export default ({ user }) => {
                     <span>Email (optional)</span><input type="email" onChange={handleEmailInput} />
                 </section>
                 <section className="email-form-button">
-                    <button disabled={sending || numWords < MIN_WORDS || numWords > MAX_WORDS} onClick={handleSubmit}>
-                        {sending ? 'Sending' : 'Send'}
+                    <button disabled={numWords < MIN_WORDS || numWords > MAX_WORDS} onClick={handleSubmit}>
+                        Send
                     </button>
                 </section>
             </div>

--- a/app/client/jsx/EmailForm.jsx
+++ b/app/client/jsx/EmailForm.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react'
+import { HttpApi } from './WebAPI.jsx'
+
+
+export default ({ user }) => {
+    const MIN_WORDS = 10
+    const MAX_WORDS = 500
+
+    const httpApi = new HttpApi()
+
+    const [email, setEmail] = useState('')
+    const [message, setMessage] = useState('')
+    const [sending, setSending] = useState(false)
+    const [sent, setSent] = useState(false)
+
+    const numWords = message.split(/\s+/).length - 1
+    const wordCountClass = numWords < MIN_WORDS || numWords === MAX_WORDS ? 'bad-word-count' : ''
+
+    const handleMessageInput = event => {
+        if (numWords <= MAX_WORDS) {
+            setMessage(event.target.value)
+        }
+    }
+    const handleEmailInput = event => setEmail(event.target.value)
+    const handleSubmit = async () => {
+        // TODO email validation
+        // TODO don't modify inputs while sending
+        setSending(true)
+        const { success } = await httpApi.emailModerators(message, email, user)
+        if (success) {
+            setSent(true)
+        }
+    }
+
+    return sent ?
+        (
+            <div className="email-form">
+                <div className="email-sent">Message sent!</div>
+            </div>
+        ) :
+        (
+            <div className="email-form">
+                <section className="email-form-instructions">
+                    If you have any questions or concerns, please send us a message and our moderators will address it as soon as possible.
+                    Please include your email address if you want a moderator to contact you back directly. 
+                </section>
+                <section className="email-form-message">
+                    <div>Your message <span className={wordCountClass}>({numWords} / {MAX_WORDS})</span></div>
+                    <textarea
+                        // placeholder={PLACEHOLDER}
+                        autoFocus="autofocus"
+                        disabled={sending}
+                        value={message}
+                        onChange={handleMessageInput}/>
+                </section>
+                <section className="email-form-email">
+                    <span>Email (optional)</span><input type="email" onChange={handleEmailInput} />
+                </section>
+                <section className="email-form-button">
+                    <button disabled={sending || numWords < MIN_WORDS || numWords > MAX_WORDS} onClick={handleSubmit}>
+                        {sending ? 'Sending' : 'Send'}
+                    </button>
+                </section>
+            </div>
+        )
+}

--- a/app/client/jsx/EmailForm.jsx
+++ b/app/client/jsx/EmailForm.jsx
@@ -38,6 +38,9 @@ export default ({ user }) => {
     const numWords = message.split(/\s+/).length - 1
     const wordCountClass = numWords < MIN_WORDS || numWords === MAX_WORDS ? 'bad-word-count' : ''
 
+    const emailRegex = new RegExp(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/)
+    const isBadEmailInput = !emailRegex.test(email) && email !== ''
+
     const handleMessageInput = event => {
         if (numWords <= MAX_WORDS) {
             setMessage(event.target.value)
@@ -45,7 +48,6 @@ export default ({ user }) => {
     }
     const handleEmailInput = event => setEmail(event.target.value)
     const handleSubmit = async () => {
-        // TODO email validation
         setSent(true)
         const { success } = await httpApi.emailModerators(message, email, user)
         setStatus(success ? 'succeeded' : 'failed')
@@ -76,10 +78,11 @@ export default ({ user }) => {
                         onChange={handleMessageInput}/>
                 </section>
                 <section className="email-form-email">
-                    <span>Email (optional)</span><input type="email" onChange={handleEmailInput} />
+                    <span>Email (optional)</span>
+                    <input type="email" onChange={handleEmailInput} className={isBadEmailInput ? 'bad-email-input' : ''} />
                 </section>
                 <section className="email-form-button">
-                    <button disabled={numWords < MIN_WORDS || numWords > MAX_WORDS} onClick={handleSubmit}>
+                    <button disabled={numWords < MIN_WORDS || numWords > MAX_WORDS || isBadEmailInput} onClick={handleSubmit}>
                         Send
                     </button>
                 </section>

--- a/app/client/jsx/EmailForm.jsx
+++ b/app/client/jsx/EmailForm.jsx
@@ -9,6 +9,11 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 
 
+function getNumWords(str) {
+    const match = str.match(/\w+/g)
+    return match && match.length || 0
+}
+
 export default ({ user }) => {
     const MIN_WORDS = 10
     const MAX_WORDS = 500
@@ -35,14 +40,17 @@ export default ({ user }) => {
     const [sent, setSent] = useState(false)
     const [status, setStatus] = useState('sending')
 
-    const numWords = message.split(/\s+/).length - 1
+    const numWords = getNumWords(message)
     const wordCountClass = numWords < MIN_WORDS || numWords === MAX_WORDS ? 'bad-word-count' : ''
 
     const emailRegex = new RegExp(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/)
     const isBadEmailInput = !emailRegex.test(email) && email !== ''
 
     const handleMessageInput = event => {
-        if (numWords <= MAX_WORDS) {
+        const newMsg = event.target.value
+        const added = newMsg.slice(message.length - 1, newMsg.length)
+        const numWordsAdded = getNumWords(added)
+        if (numWords + numWordsAdded <= MAX_WORDS) {
             setMessage(event.target.value)
         }
     }

--- a/app/client/jsx/ModalFactory.jsx
+++ b/app/client/jsx/ModalFactory.jsx
@@ -1,0 +1,29 @@
+import _ from 'lodash'
+import React from 'react'
+import Map from './Map.jsx'
+import EventList from './EventList.jsx'
+import EmailForm from './EmailForm.jsx'
+import CustomComponents from './CustomComponents'
+
+export default ({ room, modal, props = {} }) => {
+    if (modal in CustomComponents) {
+        const Component = CustomComponents[modal]
+        return <Component room={room} {...props} />
+    }
+    const map = (
+        <Map
+            onRoomClick={room.onSwitchRoom.bind(room)}
+            handleCloseMap={() => room.handleModalChange(null)}>
+        </Map>
+    )
+    const events = (
+        <EventList
+            rooms={room.props.rooms}
+            events={room.props.events}>
+        </EventList>
+    )
+    const email = (
+        <EmailForm user={room.props.user}></EmailForm>
+    )
+    return { map, events, email }[modal] || null
+}

--- a/app/client/jsx/Navigation.jsx
+++ b/app/client/jsx/Navigation.jsx
@@ -113,7 +113,7 @@ class Navigation extends Component {
                         }
                     </div>
                     <div className="email-button-container">
-                        {!_.isEmpty(Config.moderatorEmails) &&
+                        {Config.moderation && !_.isEmpty(Config.moderation.moderatorEmails) &&
                             <button className="email-button" onClick={handleClickEmail}>
                                 <FontAwesomeIcon icon={faEnvelope}/>
                             </button>

--- a/app/client/jsx/Navigation.jsx
+++ b/app/client/jsx/Navigation.jsx
@@ -13,7 +13,8 @@ import {
     faArrowLeft,
     faArrowRight,
     faMap,
-    faCalendar
+    faCalendar,
+    faEnvelope
 } from '@fortawesome/free-solid-svg-icons'
 
 class Navigation extends Component {
@@ -87,12 +88,16 @@ class Navigation extends Component {
         const events = this.props.events
         const users = _.flatten(Object.values(this.props.users))
 
+        const handleClickMap = () => this.props.handleOpenModal('map')
+        const handleClickEvents = () => this.props.handleOpenModal('events')
+        const handleClickEmail = () => this.props.handleOpenModal('email')
+
         return (
             <div className="navigation-container">
                 <div className="column settings-container">
                     <div className="map-button-container">
                         {this.props.showMapButton && !this.props.hideSettings &&
-                            <button className={mapButtonClass} disabled={false} onClick={this.props.handleOpenMap.bind(this)}>
+                            <button className={mapButtonClass} disabled={false} onClick={handleClickMap}>
                                 <FontAwesomeIcon icon={faMap}/>
                             </button>
                         }
@@ -102,8 +107,15 @@ class Navigation extends Component {
                     </div>
                     <div className="events-button-container">
                         {events && events.length > 0 && !this.props.hideSettings &&
-                            <button className="events-button" onClick={this.props.handleOpenEvents.bind(this)}>
+                            <button className="events-button" onClick={handleClickEvents}>
                                 <FontAwesomeIcon icon={faCalendar}/>
+                            </button>
+                        }
+                    </div>
+                    <div className="email-button-container">
+                        {!_.isEmpty(Config.moderatorEmails) &&
+                            <button className="email-button" onClick={handleClickEmail}>
+                                <FontAwesomeIcon icon={faEnvelope}/>
                             </button>
                         }
                     </div>

--- a/app/client/jsx/Room.jsx
+++ b/app/client/jsx/Room.jsx
@@ -4,11 +4,10 @@ import reducers from './reducers.jsx'
 import { Redirect } from 'react-router-dom'
 import { Beforeunload } from 'react-beforeunload';
 import Modal from 'react-modal';
+import ModalFactory from './ModalFactory.jsx'
 import JitsiVideo from './JitsiVideo.jsx'
 import ArtRoom from './ArtRoom.jsx'
 import IFrameRoom from './IFrameRoom.jsx'
-import Map from './Map.jsx'
-import EventList from './EventList.jsx'
 import Door from './Door.jsx'
 import Adventure from './Adventure.jsx'
 import Navigation from './Navigation.jsx'
@@ -162,20 +161,8 @@ class Room extends Component {
         this.socketApi.leaveRoom(this.props.user, this.state.room)
     }
 
-    handleOpenMap() {
-        this.setState({ showMap: true })
-    }
-
-    handleCloseMap() {
-        this.setState({ showMap: false })
-    }
-
-    handleOpenEvents() {
-        this.setState({ showEvents: true })
-    }
-
-    handleCloseEvents() {
-        this.setState({ showEvents: false })
+    handleModalChange(modal) {
+        this.setState({ modal })
     }
 
     computeMapState(room) {
@@ -254,20 +241,13 @@ class Room extends Component {
                     showMapButton={mapState.mapVisible}
                     showMapTooltip={mapState.showMapTooltip}
                     hideSettings={room.type === 'adventure'}
-                    handleOpenMap={this.handleOpenMap.bind(this)}
-                    handleOpenEvents={this.handleOpenEvents.bind(this)}></Navigation>
+                    handleOpenModal={this.handleModalChange.bind(this)}></Navigation>
                 <Beforeunload onBeforeunload={this.handleBeforeUnload.bind(this)} />
                 <Modal
-                    isOpen={this.state.showMap}
-                    onAfterOpen={this.handleOpenMap.bind(this)}
-                    onRequestClose={this.handleCloseMap.bind(this)}>
-                        <Map onRoomClick={this.onSwitchRoom.bind(this)} handleCloseMap={this.handleCloseMap.bind(this)}></Map>
-                </Modal>
-                <Modal
-                    isOpen={this.state.showEvents}
-                    onRequestClose={this.handleCloseEvents.bind(this)}
-                    className="event-modal">
-                        <EventList rooms={this.props.rooms} events={this.props.events}></EventList>
+                    isOpen={!!this.state.modal}
+                    onRequestClose={() => this.handleModalChange(null)}
+                    className={`${this.state.modal}-modal`}>
+                        <ModalFactory room={this} modal={this.state.modal} />
                 </Modal>
                 {!!this.state.pokeData && <PokeNotification {...this.state.pokeData} />}
             </div>

--- a/app/client/jsx/WebAPI.jsx
+++ b/app/client/jsx/WebAPI.jsx
@@ -71,4 +71,17 @@ export class HttpApi {
             return { success: false }
         }
     }
+
+    async emailModerators(message, email, user) {
+        try {
+            const request = `${url}/email_moderators`
+            await axios.post(request, {
+                params: { message, email, user }
+            })
+            return { success: true }
+        } catch (err) {
+            console.log(err)
+            return { success: false }
+        }
+    }
 }

--- a/app/client/styles/components/_email.scss
+++ b/app/client/styles/components/_email.scss
@@ -6,6 +6,7 @@
 
 .email-form {
     padding: 20px 40px;
+    color: $email-description-color;
 
     section {
         margin: 20px 0;
@@ -13,6 +14,7 @@
     textarea {
         width: 100%;
         height: 300px;
+        color: $email-form-color;
     }
     input {
         margin-left: 10px;
@@ -21,6 +23,9 @@
         outline: none;
         border: 2px solid $accent-color !important;
         border-radius: 5px !important;
+    }
+    .email-form-message span {
+        color: color('blue-300');
     }
     .email-form-message .bad-word-count {
         color: $accent-color;

--- a/app/client/styles/components/_email.scss
+++ b/app/client/styles/components/_email.scss
@@ -17,6 +17,11 @@
     input {
         margin-left: 10px;
     }
+    input.bad-email-input, input.bad-email-input:focus {
+        outline: none;
+        border: 2px solid $accent-color !important;
+        border-radius: 5px !important;
+    }
     .email-form-message .bad-word-count {
         color: $accent-color;
     }

--- a/app/client/styles/components/_email.scss
+++ b/app/client/styles/components/_email.scss
@@ -1,0 +1,23 @@
+.ReactModal__Content.email-modal {
+    width: 60%;
+    left: 20%;
+    height: fit-content;
+}
+
+.email-form {
+    padding: 20px 40px;
+
+    section {
+        margin: 20px 0;
+    }
+    textarea {
+        width: 100%;
+        height: 300px;
+    }
+    input {
+        margin-left: 10px;
+    }
+    .email-form-message .bad-word-count {
+        color: $accent-color;
+    }
+}

--- a/app/client/styles/components/_email.scss
+++ b/app/client/styles/components/_email.scss
@@ -20,4 +20,23 @@
     .email-form-message .bad-word-count {
         color: $accent-color;
     }
+    .email-status {
+        display: flex;
+        flex-direction: row;
+    }
+    .email-status-label {
+        margin-left: 20px;
+    }
+    .email-status-icon {
+        align-self: center;
+
+        svg {
+            font-size: xx-large;
+        }
+    }
+    .original-message {
+        font-size: smaller;
+        border-left: 10px solid lightgrey;
+        padding: 0 20px;
+    }
 }

--- a/app/client/styles/components/_email.scss
+++ b/app/client/styles/components/_email.scss
@@ -41,7 +41,7 @@
     }
     .original-message {
         font-size: smaller;
-        border-left: 10px solid lightgrey;
+        border-left: 10px solid color('grey-200');
         padding: 0 20px;
     }
 }

--- a/app/client/styles/components/_eventList.scss
+++ b/app/client/styles/components/_eventList.scss
@@ -53,7 +53,7 @@
     }
 }
 
-.ReactModal__Content.event-modal {
+.ReactModal__Content.events-modal {
     position: absolute;
     width: 50%;
     max-height: 85%;

--- a/app/client/styles/components/_modal.scss
+++ b/app/client/styles/components/_modal.scss
@@ -1,7 +1,16 @@
 .ReactModal__Content {
 	border: none !important;
-	background: $modal-background-color !important;
-	box-shadow: 2px 2px 4px darken($background-color, 30%);
+    background: $modal-background-color !important;
+    position: absolute;
+    top: 40px;
+    left: 40px;
+    right: 40px;
+    bottom: 40px;
+    overflow: auto;
+    border-radius: 4px;
+    outline: none;
+    padding: 20px;
+	box-shadow: 2px 2px 4px darken($modal-background-color, 30%);
 }
 .ReactModal__Overlay {
 	z-index: 10;

--- a/app/client/styles/main.scss
+++ b/app/client/styles/main.scss
@@ -41,7 +41,8 @@
   'components/userList',
   'components/audioPlayer',
   'components/eventList',
-  'components/poke';
+  'components/poke',
+  'components/email';
 
 // 7. Page-specific styles
 @import

--- a/app/client/styles/themes/_bauhaus.scss
+++ b/app/client/styles/themes/_bauhaus.scss
@@ -44,6 +44,9 @@ $map-highlight-fill: $yellow;
 $events-header-color: $black;
 $events-header-background-color: $yellow;
 
+$email-form-color: $grey;
+$email-description-color: $black;
+
 $poke-color: $pink;
 $poke-background-color: $black;
 

--- a/app/config.py
+++ b/app/config.py
@@ -35,8 +35,6 @@ class Config:
     MAIL_PORT = 465
     MAIL_USERNAME = os.getenv('MAIL_USERNAME')
     MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
-
-    # TODO change this to True
     MAIL_USE_TLS = False
     MAIL_USE_SSL = True
 

--- a/app/config.py
+++ b/app/config.py
@@ -62,7 +62,7 @@ class Config:
 
     @property
     def MODERATOR_EMAILS(self):
-        return self.merged_cfg.get('moderatorEmails')
+        return self.merged_cfg.get('moderation', {}).get('moderatorEmails')
 
 
 class DevelopmentConfig(Config):

--- a/app/config.py
+++ b/app/config.py
@@ -31,6 +31,15 @@ class Config:
     ]]
     OVERRIDE_PATHS = [os.path.join(overridedir, file) for file in ['config.json', 'rooms.json', 'events.json']]
 
+    MAIL_SERVER = 'smtp.gmail.com'
+    MAIL_PORT = 465
+    MAIL_USERNAME = os.getenv('MAIL_USERNAME')
+    MAIL_PASSWORD = os.getenv('MAIL_PASSWORD')
+
+    # TODO change this to True
+    MAIL_USE_TLS = False
+    MAIL_USE_SSL = True
+
     @staticmethod
     def init_app(app):
         pass
@@ -50,6 +59,10 @@ class Config:
     @property
     def EVENTS(self):
         return self.merged_cfg.get('events', {})
+
+    @property
+    def MODERATOR_EMAILS(self):
+        return self.merged_cfg.get('moderatorEmails')
 
 
 class DevelopmentConfig(Config):

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -5,6 +5,7 @@
 	"overrideJitsiServerUrlWithWindowHost": false,
 	"noJitsiServerSSL": false,
 	"useLocalSessions": true,
+	"moderatorEmails": [],
 	"startRoom": "vestibule",
 	"welcomePage": {
 		"avatarSelectionEnabled": true,

--- a/app/config/base.json
+++ b/app/config/base.json
@@ -5,7 +5,7 @@
 	"overrideJitsiServerUrlWithWindowHost": false,
 	"noJitsiServerSSL": false,
 	"useLocalSessions": true,
-	"moderatorEmails": [],
+	"moderation": {},
 	"startRoom": "vestibule",
 	"welcomePage": {
 		"avatarSelectionEnabled": true,

--- a/app/config/overrides/config.json
+++ b/app/config/overrides/config.json
@@ -3,6 +3,9 @@
 	"mapUnlockThreshold": 0,
 	"useLocalSessions": false,
 	"startRoom": "vestibule",
+	"moderatorEmails": [
+		"morganeciot@gmail.com"
+	],
 	"welcomePage": {
 		"avatarSelectionEnabled": true,
 		"backgroundImagePath": "./js/images/bauhaus_darker.jpg",

--- a/app/config/overrides/config.json
+++ b/app/config/overrides/config.json
@@ -3,9 +3,12 @@
 	"mapUnlockThreshold": 0,
 	"useLocalSessions": false,
 	"startRoom": "vestibule",
-	"moderatorEmails": [
-		"morganeciot@gmail.com"
-	],
+	"moderation": {
+		"moderatorEmails": [
+			"morganeciot@gmail.com"
+		],
+		"formDescription": "Someone harshing your vibe? Need a moderator to look into it? We’ll keep what you tell us private, and we’ll send someone your way as soon as you send this. Please include the time of the incident, the room in which it took place, the relevant username(s), and a brief description of the situation."
+	},
 	"welcomePage": {
 		"avatarSelectionEnabled": true,
 		"backgroundImagePath": "./js/images/bauhaus_darker.jpg",

--- a/app/jitsi/__init__.py
+++ b/app/jitsi/__init__.py
@@ -1,16 +1,21 @@
 import os
 import eventlet
+
+eventlet.monkey_patch(socket=False)
+
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_socketio import SocketIO
 from flask_cors import CORS
 from config import config, basedir
+from flask_mail import Mail
 
 
 staticdir = os.path.join(basedir, 'client/js')
 
 db = SQLAlchemy()
 socketio = SocketIO()
+mail = Mail()
 
 # Register socket events with SocketIO instance
 from . import events  # noqa
@@ -36,6 +41,9 @@ def create_app(config_name):
     # Database
     db.init_app(app)
 
+    # Email
+    mail.init_app(app)
+
     # SocketIO
     queue = app_config.MESSAGE_QUEUE
     socketio.init_app(app, cors_allowed_origins='*', message_queue=queue)
@@ -44,6 +52,5 @@ def create_app(config_name):
 
 
 def run_eventlet(app):
-    eventlet.monkey_patch()
     socketio.init_app(app, async_mode="eventlet")
     socketio.run(app, host='0.0.0.0', port=os.getenv('FLASK_RUN_PORT'))

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -69,6 +69,9 @@ def email_moderators():
         params['email'] if params.get('email') else 'Not provided'
     )
     mail.send(message)
+    import time
+    time.sleep(3)
+    x = 5 / 0
     # TODO idk about this response
     return jsonify({
         'message': 'Email was successfully sent'

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -54,6 +54,9 @@ def email_moderators():
         sender=sender,
         recipients=moderators
     )
+    formatted_message = ''.join(
+        ['<p>{0}</p>'.format(paragraph) for paragraph in params['message'].split('\n')]
+    )
     message.html = '''
         <b>The following message was sent via the moderator contact form:</b>
         <blockquote>{0}</blockquote>
@@ -63,7 +66,7 @@ def email_moderators():
         <div>User ID: {2}</div>
         <div>Email: {3}</div>
     '''.format(
-        params['message'],
+        formatted_message,
         params['user']['username'],
         params['user']['id'],
         params['email'] if params.get('email') else 'Not provided'

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -69,13 +69,7 @@ def email_moderators():
         params['email'] if params.get('email') else 'Not provided'
     )
     mail.send(message)
-    import time
-    time.sleep(3)
-    x = 5 / 0
-    # TODO idk about this response
-    return jsonify({
-        'message': 'Email was successfully sent'
-    })
+    return jsonify('message sent')
 
 
 @main.route('/', defaults={'path': ''})

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -1,16 +1,20 @@
 import os
 import json
+from . import mail
 from .models import User
 from datetime import datetime
+from flask_mail import Message
 from flask import Blueprint, send_from_directory, redirect, url_for, current_app, request, jsonify
 
 main = Blueprint('main', __name__)
+
 
 @main.route('/join', methods=['GET', 'POST'])
 def join():
     params = request.get_json()['params']
     user = User.create(**params)
     return jsonify(user.to_json())
+
 
 @main.route('/config')
 def get_config():
@@ -38,6 +42,38 @@ def get_config():
         'events': events
     }
     return jsonify(config)
+
+
+@main.route('/email_moderators', methods=['POST'])
+def email_moderators():
+    params = request.get_json()['params']
+    moderators = current_app.config['MODERATOR_EMAILS']
+    sender = current_app.config['MAIL_USERNAME']
+    message = Message(
+        'Jitsi Party Alert',
+        sender=sender,
+        recipients=moderators
+    )
+    message.html = '''
+        <b>The following message was sent via the moderator contact form:</b>
+        <blockquote>{0}</blockquote>
+        <br>
+        <b>Sender details</b>
+        <div>Username: {1}</div>
+        <div>User ID: {2}</div>
+        <div>Email: {3}</div>
+    '''.format(
+        params['message'],
+        params['user']['username'],
+        params['user']['id'],
+        params['email'] if params.get('email') else 'Not provided'
+    )
+    mail.send(message)
+    # TODO idk about this response
+    return jsonify({
+        'message': 'Email was successfully sent'
+    })
+
 
 @main.route('/', defaults={'path': ''})
 @main.route('/<path:path>')

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -1,3 +1,5 @@
 export FLASK_APP="manager.py"
 export FLASK_ENV=development
 export FLASK_RUN_PORT=3000
+
+source email_config.sh

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -3,6 +3,7 @@ dnspython==1.16.0
 eventlet==0.25.2
 Flask==1.1.1
 Flask-Cors==3.0.8
+Flask-Mail==0.9.1
 Flask-SocketIO==4.3.0
 Flask-SQLAlchemy==2.4.1
 itsdangerous==1.1.0


### PR DESCRIPTION
TST requested that users be able to send a message to a moderator. This adds an email button in the bottom lefthand corner that users can click to get to an email client:
<img width="1608" alt="Screen Shot 2020-07-21 at 5 46 42 PM" src="https://user-images.githubusercontent.com/4405597/88110482-4b6b6700-cb7a-11ea-8768-25f4bb3cbd42.png">

Sends an email to a list of moderator emails (provided in the config) that looks like:
<img width="946" alt="Screen Shot 2020-07-21 at 5 47 01 PM" src="https://user-images.githubusercontent.com/4405597/88110518-5920ec80-cb7a-11ea-9e7d-a588e3fcb4a9.png">

Please ignore the styling for now, it looks weird because the bauhaus theme is still active. I'll clean up the theming and styling in a separate PR. 