### PR TITLE
Fix z-index

### DIFF
--- a/app/client/styles/components/_poke.scss
+++ b/app/client/styles/components/_poke.scss
@@ -14,6 +14,7 @@
     padding: 10px 15px;
     max-height: 80%;
     overflow-y: auto;
+    z-index: 5;
 
     .poke-header {
         font-size: smaller;


### PR DESCRIPTION
Fixes #175 

Poke list seems to be the only relevant component affected by this. Unfortunately, the React imagemap component we're using hardcodes its z-index values, and doesn't expose any convenient class for us to use to override. So, instead we have to just bump up the poke z-index to make sure it's above the imagemap.