### PR TITLE
Support event open/close times

### DIFF
--- a/app/client/jsx/Welcome.jsx
+++ b/app/client/jsx/Welcome.jsx
@@ -58,7 +58,31 @@ class Welcome extends Component {
         this.setState({ authenticated: true })
     }
 
+    isOpen() {
+        if (!Config.eventTimes) return true;
+
+        const now = new Date()
+        if (Config.eventTimes.start) {
+            const start = Date.parse(Config.eventTimes.start)
+            if (now < start) return false;
+        }
+        if (Config.eventTimes.end) {
+            const end = Date.parse(Config.eventTimes.end)
+            if (now > end) return false;
+        }
+
+        return true
+    }
+
     render() {
+        if (!isOpen()) {
+            return (
+                <div className="eventClosed">
+                    {Config.eventTimes.closedPage}
+                </div>
+            )
+        }
+
         const config = Config.welcomePage
         const splash = config.backgroundImagePath
             ? <img className="splash" src={config.backgroundImagePath}/>

--- a/app/client/jsx/Welcome.jsx
+++ b/app/client/jsx/Welcome.jsx
@@ -75,14 +75,6 @@ class Welcome extends Component {
     }
 
     render() {
-        if (!isOpen()) {
-            return (
-                <div className="eventClosed">
-                    {Config.eventTimes.closedPage}
-                </div>
-            )
-        }
-
         const config = Config.welcomePage
         const splash = config.backgroundImagePath
             ? <img className="splash" src={config.backgroundImagePath}/>
@@ -93,11 +85,17 @@ class Welcome extends Component {
             <CustomAuthWrapper options={config.auth} onAuthentication={this.onAuthentication.bind(this)} /> :
             <Login/>
 
+        const closed = (
+            <div className="eventClosed">
+                <h1>{Config.eventTimes.closedText}</h1>
+            </div>
+        )
+
         return (
             <div className="vestibule">
                 <div className="header" dangerouslySetInnerHTML={{ __html: config.headerHtml }} />
                 {splash}
-                {login}
+                {this.isOpen() ? login : closed}
             </div>
         )
     }

--- a/app/config.py
+++ b/app/config.py
@@ -140,6 +140,10 @@ class Config:
     def NUM_PROXIES(self):
         return self.config['numProxies']
 
+    @property
+    def EVENT_TIMES(self):
+        return self.config.get('eventTimes', {})
+
 
 class DevelopmentConfig(Config):
     SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, 'db.sqlite')

--- a/app/config/schema/config.proto
+++ b/app/config/schema/config.proto
@@ -82,7 +82,7 @@ message Config {
     // Overall start and stop times for the space
     // Users will be unable to join the jitsi-party outside of these time bounds
     // Optional. If not provided, event defaults to open.
-    EventTimeConfig event_times = 15;
+    EventTimeConfig event_times = 16;
 }
 
 message Moderation {

--- a/app/config/schema/config.proto
+++ b/app/config/schema/config.proto
@@ -231,4 +231,8 @@ message EventTimeConfig {
     // ISO-8601 timestamp for when the space closes
     // Optional.
     string end = 5;
+
+    // HTML to display when the space is closed 
+    // Required (if using start or end times).
+    string closed_html = 6;
 }

--- a/app/config/schema/config.proto
+++ b/app/config/schema/config.proto
@@ -78,6 +78,11 @@ message Config {
     // Number of server-side proxies in use (if unsure, probably 0)
     // Required.
     int32 num_proxies = 14;
+
+    // Overall start and stop times for the space
+    // Users will be unable to join the jitsi-party outside of these time bounds
+    // Optional. If not provided, event defaults to open.
+    EventTimeConfig event_times = 15;
 }
 
 message Moderation {
@@ -216,4 +221,14 @@ message PokeConfig {
     // How long after joining that a user is allowed to use pokes
     // Required.
     int32 unlock_after_minutes = 7;
+}
+
+message EventTimeConfig {
+    // ISO-8601 timestamp for when the space opens
+    // Optional.
+    string start = 4;
+
+    // ISO-8601 timestamp for when the space closes
+    // Optional.
+    string end = 5;
 }

--- a/app/config/schema/config.proto
+++ b/app/config/schema/config.proto
@@ -232,7 +232,7 @@ message EventTimeConfig {
     // Optional.
     string end = 5;
 
-    // HTML to display when the space is closed 
+    // Text to display when the space is closed 
     // Required (if using start or end times).
-    string closed_html = 6;
+    string closed_text = 6;
 }

--- a/app/config/tstvhq/config.json
+++ b/app/config/tstvhq/config.json
@@ -92,5 +92,9 @@
         "unlockText": "You have unlocked the ability to hex",
         "selfPoke": "Ouch",
         "unlockAfterMinutes": 0
+    },
+    "eventTime": {
+        "start": "2020-08-27T19:00:00-04:00",
+        "end": "2020-08-27T01:00:00-04:00",
     }
 }

--- a/app/config/tstvhq/config.json
+++ b/app/config/tstvhq/config.json
@@ -96,6 +96,6 @@
     "eventTimes": {
         "start": "2020-08-27T19:00:00-04:00",
         "end": "2020-08-27T01:00:00-04:00",
-        "closed_html": "<h1>Sorry, event is closed</h1>"
+        "closedText": "Sorry, the event is closed"
     }
 }

--- a/app/config/tstvhq/config.json
+++ b/app/config/tstvhq/config.json
@@ -93,8 +93,9 @@
         "selfPoke": "Ouch",
         "unlockAfterMinutes": 0
     },
-    "eventTime": {
+    "eventTimes": {
         "start": "2020-08-27T19:00:00-04:00",
         "end": "2020-08-27T01:00:00-04:00",
+        "closed_html": "<h1>Sorry, event is closed</h1>"
     }
 }

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -8,7 +8,7 @@ from .models import User
 from datetime import datetime
 from twilio.rest import Client
 from flask import Blueprint, send_from_directory, redirect, url_for, current_app, request, jsonify
-from datetime import datetime
+from datetime import datetime, timezone
 
 main = Blueprint('main', __name__)
 logger = logging.getLogger(__name__)
@@ -167,7 +167,7 @@ def compute_ip(num_proxies=0):
 
 def is_open():
     times = current_app.config.get("EVENT_TIMES")
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     if "start" in times:
         start_time = datetime.fromisoformat(times["start"])
         if (now < start_time):

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -172,7 +172,7 @@ def is_open():
         start_time = datetime.fromisoformat(times["start"])
         if (now < start_time):
             return false
-    if "end" in times>:
+    if "end" in times:
         end_time = datetime.fromisoformat(times["end"])
         if (now > end_time):
             return false

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -8,12 +8,15 @@ from .models import User
 from datetime import datetime
 from twilio.rest import Client
 from flask import Blueprint, send_from_directory, redirect, url_for, current_app, request, jsonify
+from datetime import datetime
 
 main = Blueprint('main', __name__)
 logger = logging.getLogger(__name__)
 
 @main.route('/join', methods=['GET', 'POST'])
 def join():
+    if not is_open():
+        return "Event is not currently open", 400
     num_proxies = current_app.config['NUM_PROXIES']
     params = request.get_json()['params']
     params['ip'] = compute_ip(num_proxies)
@@ -162,3 +165,15 @@ def compute_ip(num_proxies=0):
     else:
         return headers_list[-1 * num_proxies]
 
+def is_open():
+    times = current_app.config.get("EVENT_TIMES")
+    now = datetime.now()
+    if "start" in times:
+        start_time = datetime.fromisoformat(times["start"])
+        if (now < start_time):
+            return false
+    if "end" in times>:
+        end_time = datetime.fromisoformat(times["end"])
+        if (now > end_time):
+            return false
+    return true

--- a/app/jitsi/main.py
+++ b/app/jitsi/main.py
@@ -171,9 +171,9 @@ def is_open():
     if "start" in times:
         start_time = datetime.fromisoformat(times["start"])
         if (now < start_time):
-            return false
+            return False
     if "end" in times:
         end_time = datetime.fromisoformat(times["end"])
         if (now > end_time):
-            return false
-    return true
+            return False
+    return True


### PR DESCRIPTION
This adds a config option for open/close times. This will not boot users after the close time, but it will prevent users from joining before or after an event.

Screenshot of display outside of event times:
![Screenshot 2020-08-27 at 9 08 37 PM](https://user-images.githubusercontent.com/1207742/91510192-56689400-e8aa-11ea-9786-18de1451c298.png)
