### PR TITLE
don't check the event config if it's not present

### DIFF
--- a/app/client/jsx/Welcome.jsx
+++ b/app/client/jsx/Welcome.jsx
@@ -85,11 +85,11 @@ class Welcome extends Component {
             <CustomAuthWrapper options={config.auth} onAuthentication={this.onAuthentication.bind(this)} /> :
             <Login/>
 
-        const closed = (
+        const closed = Config.eventTimes ? (
             <div className="eventClosed">
                 <h1>{Config.eventTimes.closedText}</h1>
             </div>
-        )
+        ) : null
 
         return (
             <div className="vestibule">


### PR DESCRIPTION
the statement was getting evaluated eagerly regardless of config existence