### PR TITLE
Disable sharing for iframe rooms

### DIFF
--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -13,11 +13,31 @@ class JitsiVideo extends Component {
             hasLoaded: false
         }
         this.toolbarButtons = [
-            'microphone', 'camera', 'closedcaptions', 'desktop', 'fullscreen',
-            'fodeviceselection', 'profile', 'chat', 'recording',
-            'livestreaming', 'etherpad', 'sharedvideo', 'settings', 'raisehand',
-            'videoquality', 'filmstrip', 'invite', 'feedback', 'stats', 'shortcuts',
-            'tileview', 'videobackgroundblur', 'download', 'help', 'mute-everyone',
+            'microphone',           // toggle sound on and off
+            'camera',               // toggle video on and off
+            'closedcaptions',
+            'desktop',              // share screen
+            'fullscreen',           // full screen
+            'fodeviceselection',    // more actions > settings > devices
+            'profile',              // more actions > settings > profile
+            'chat',                 // open/close text chat
+            // 'recording',         // start recording
+            'livestreaming',        // start a live stream
+            'etherpad',
+            'sharedvideo',          // share a youtube video
+            'settings',             // additional settings
+            'raisehand',            // raise hand
+            'videoquality',         // manage video quality
+            'filmstrip',
+            // 'invite',            // invite more people (off by default to hide jitsi room URLs)
+            // 'feedback',          // send feedback to jitsi
+            'stats',                // speaker stats
+            'shortcuts',            // shortcut to settings
+            'tileview',
+            'videobackgroundblur',
+            'download',
+            // 'help',              // link to jitsi meet handbook
+            'mute-everyone',        // yup, you can mute everyone! but they can unmute themselves
             'e2ee'
         ]
 
@@ -87,6 +107,12 @@ class JitsiVideo extends Component {
             if (this.props.jitsiData.hideVideo) {
                 toolbarButtons = _.without(toolbarButtons, 'camera')
             }
+            // remove screensharing, youtube video sharing, and livestreaming
+            if (this.props.jitsiData.disableSharing) {
+                toolbarButtons = _.without(toolbarButtons, 'desktop', 'sharedvideo', 'livestreaming')
+            }
+
+            console.log(toolbarButtons, this.props.jitsiData)
 
             let domain = Config.jitsiServerUrl
             if (Config.overrideJitsiServerUrlWithWindowHost) {
@@ -98,7 +124,7 @@ class JitsiVideo extends Component {
                 roomName: this.props.jitsiData.roomName,
                 parentNode: document.getElementById('jitsi-container'),
                 interfaceConfigOverwrite: {
-                    filmStripOnly: true,
+                    // filmStripOnly: true,
                     SHOW_JITSI_WATERMARK: false,
                     DEFAULT_REMOTE_DISPLAY_NAME: Config.videoDisplayName,
                     SHOW_WATERMARK_FOR_GUESTS: false,

--- a/app/client/jsx/JitsiVideo.jsx
+++ b/app/client/jsx/JitsiVideo.jsx
@@ -112,8 +112,6 @@ class JitsiVideo extends Component {
                 toolbarButtons = _.without(toolbarButtons, 'desktop', 'sharedvideo', 'livestreaming')
             }
 
-            console.log(toolbarButtons, this.props.jitsiData)
-
             let domain = Config.jitsiServerUrl
             if (Config.overrideJitsiServerUrlWithWindowHost) {
                 domain = `${window.location.host}/jitsi`

--- a/app/client/jsx/Room.jsx
+++ b/app/client/jsx/Room.jsx
@@ -59,7 +59,7 @@ class Room extends Component {
         this.socketApi.startPinging(this.props.user.id)
         this.socketApi.on('user-event', this.props.updateUsers.bind(this))
         this.socketApi.on(`poke-${this.props.user.id}`, this.handlePoke.bind(this))
-        
+
         this.computePokeUnlockedState()
     }
 
@@ -82,7 +82,8 @@ class Room extends Component {
             avatar: this.props.user.avatar,
             roomName: this.state.room,
             muteRoom: roomData.muteRoom,
-            hideVideo: roomData.hideVideo
+            hideVideo: roomData.hideVideo,
+            disableSharing: roomData.type === 'IFRAME'
         }
         return {
             ART: <ArtRoom jitsiData={jitsiData} art={roomData.art}></ArtRoom>,
@@ -259,7 +260,7 @@ class Room extends Component {
                     isOpen={!!this.state.modal}
                     onRequestClose={() => this.handleModalChange(null)}
                     className={`${this.state.modal}-modal`}>
-                        <ModalFactory room={this} modal={this.state.modal} />
+                    <ModalFactory room={this} modal={this.state.modal} />
                 </Modal>
                 {!!this.state.pokeData && <PokeNotification {...this.state.pokeData} />}
             </div>
@@ -270,5 +271,5 @@ class Room extends Component {
 export default connect(state => state, {
     updateUsers: reducers.updateUsersActionCreator,
     updateCurrentRoom: reducers.updateCurrentRoomActionCreator,
-    unlockPoking: reducers.unlockPokingActionCreator 
+    unlockPoking: reducers.unlockPokingActionCreator
 })(Room)


### PR DESCRIPTION
This disables screensharing, YouTube video sharing, and livestreaming for iframe rooms. It also cleans up some of the toolbar options, getting rid of ones that seemed unnecessary. 

Addresses https://github.com/morganecf/jitsi-party/issues/204