### PR TITLE
Increase proxy buffer busy size

### DIFF
--- a/proxy/rootfs/usr/local/openresty/nginx/conf/proxy.conf
+++ b/proxy/rootfs/usr/local/openresty/nginx/conf/proxy.conf
@@ -18,6 +18,7 @@ proxy_set_header Connection "";
 proxy_cache_bypass $cookie_session;
 proxy_no_cache $cookie_session;
 proxy_buffers 32 4k;
+proxy_busy_buffers_size 1MB;
 proxy_headers_hash_bucket_size 128;
 proxy_headers_hash_max_size 1024;
 


### PR DESCRIPTION
So we stop buffering to disk when serving upstream js bundles