### PR TITLE
fix for bug resulting from converse.js trying to update the .chat-hea…

### DIFF
--- a/app/client/jsx/ChatStreamRoom.jsx
+++ b/app/client/jsx/ChatStreamRoom.jsx
@@ -93,7 +93,7 @@ export const ChatStreamRoom = ({
     // use MutationObserver to restucture the chatbox
     const observer = new MutationObserver((muts) => {
       if (document.querySelector(".chatbox-title__buttons") !== null) {
-        document.querySelector(".chat-head").remove();
+        document.querySelector(".chat-head").innerHTML = '';
       }
 
       if (document.querySelector(".chat-textarea") !== null) {


### PR DESCRIPTION
# Issue
The chat room has a recurring error in the logs: `converse.min.js:178 Uncaught (in promise) TypeError: Cannot read property 'firstChild' of null`. It appears that Converse.js is trying to find the `.chat-head-chatroom` class which is removed by our code.

# Solution
Instead of removing the `.chat-head` element which also contains the `.chat-head-chatroom` class the code is altered to remove the children of the `.chat-head` element. This seems to alleviate the error that was being caused.  