### PR TITLE
changes to support jitsi-party issue #513

### DIFF
--- a/app/client/jsx/Map.jsx
+++ b/app/client/jsx/Map.jsx
@@ -26,8 +26,8 @@ class Map extends Component {
                 return room
             })
 
-        const width = document.querySelector('.map').clientWidth / 2.5
-        const height = document.querySelector('.map').clientHeight / 1.25
+        const width = document.querySelector('.map').clientWidth / Config.mapSizeRatio.width
+        const height = document.querySelector('.map').clientHeight / Config.mapSizeRatio.height
         const padding = 10;
         const mouseEvents = {
             onRoomClick: room => {

--- a/app/config/base/config.json
+++ b/app/config/base/config.json
@@ -6,6 +6,10 @@
     "overrideJitsiServerUrlWithWindowHost": true,
     "noJitsiServerSSL": false,
     "useLocalSessions": true,
+    "mapSizeRatio": {
+        "width": 1.5,
+        "height": 1.25
+    },
     "moderation": {},
     "startRoom": "vestibule",
     "welcomePage": {

--- a/app/config/schema/config.proto
+++ b/app/config/schema/config.proto
@@ -30,6 +30,10 @@ message Config {
     // Required.
     Tooltip tooltips = 19;
 
+    // Defines the map width/height ratios for sizing and scaling the Map.
+    // Required.
+    MapSizeRatio mapSizeRatio = 20;
+
     // What base URL to use for iframing Jitsi video calls
     // Can be overridden by "overrideJitsiServerUrlWithWindowHost" (see below)
     // Optional. If not set, "overrideJitsiServerUrlWithWindowHost" must be true.
@@ -262,4 +266,14 @@ message Tooltip {
     // Tooltip for the poke/hex icon
     // Required.
     string poke = 4;
+}
+
+message MapSizeRatio {
+    // Width ratio used for scaling the map svg width
+    // Required.
+    float width = 1;
+
+    // Height ratio used for scaling the map svg height
+    // Required.
+    float height = 2;
 }

--- a/app/config/temple/config.json
+++ b/app/config/temple/config.json
@@ -9,6 +9,10 @@
         "moderator": "Contact a Caretaker",
         "poke": "Sing to Someone"
     },
+    "mapSizeRatio": {
+        "width": 2.5,
+        "height": 1.25
+    },
     "startRoom": "narthex",
     "videoDisplayName": "Guest",
     "moderation": {


### PR DESCRIPTION
# Issue
Per Issue #513, there is a need to make the map sizing and scaling configurable rather than a set of hard coded values.
 
# Solution
Added configuration definitions/settings to set the default and overrides for the **mapSizeRatio** in the **_config.json_** files.