### PR TITLE
Estate persistence

### DIFF
--- a/app/client/jsx/ChatStreamRoom.jsx
+++ b/app/client/jsx/ChatStreamRoom.jsx
@@ -22,6 +22,9 @@ function clearStorage() {
       sessionStorage.removeItem(ssKey)
     }
   }
+
+  // clear IndexedDB
+  window.indexedDB.deleteDatabase('converse-persistent')
 }
 
 /**
@@ -48,6 +51,8 @@ export const ChatStreamRoom = ({
   useEffect(() => {
     let logout = null;
     let plugins = null;
+
+    clearStorage();
 
     // configure the 'jitsi-plugin' to get our hands on the converse api logout
     try {
@@ -98,6 +103,7 @@ export const ChatStreamRoom = ({
       view_mode: "embedded",
       message_archiving: "always",
       debug: true,
+      persistent_store: "IndexedDB",
       muc_history_max_stanzas: 500,
     });
 
@@ -163,12 +169,14 @@ export const ChatStreamRoom = ({
     window.addEventListener("beforeunload", () => {
       plugins["jitsi-plugin"] = undefined;
       logout();
+      clearStorage();
     });
 
     // call the converse api logout at cleanup
     return () => {
       plugins["jitsi-plugin"] = undefined;
       logout();
+      clearStorage();
     };
   }, [resetTime]);
 

--- a/app/config/temple/rooms.json
+++ b/app/config/temple/rooms.json
@@ -194,7 +194,7 @@
         {
             "id": "sanctuary",
             "name": "The Sanctuary",
-            "capacity": 2,
+            "capacity": 50,
             "muteRoom": true,
             "hideVideo": true,
             "description": "brithdya for freind is surpr1se",


### PR DESCRIPTION
# Issue
It was reported that localStorage was maxing out at 5M. Need to switch Converse to use IndexedDB and perform more comprehensive clean up.

# Solution
Left the cleanup of any localStore and sessionStorage (applied it in a few more places to ensure proper cleanup). Configured Converse to use IndexedDB and added the database deletion to the clean up process.